### PR TITLE
Add different list types, keep everything working

### DIFF
--- a/app/controllers/grocery_list_items_controller.rb
+++ b/app/controllers/grocery_list_items_controller.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 # no doc
-class ItemsController < ApplicationController
+class GroceryListItemsController < ApplicationController
   def create
-    list = List.find(params[:list_id])
-    @item = list.items.build(item_params)
+    @item = GroceryListItem
+            .create(item_params.merge!(grocery_list_id: params[:list_id]))
 
     if @item.save
       render json: @item
@@ -14,7 +14,7 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    item = Item.find(params[:id])
+    item = GroceryListItem.find(params[:id])
     respond_to do |format|
       format.html { render template: "lists/index" }
       format.json { render json: item }
@@ -22,7 +22,7 @@ class ItemsController < ApplicationController
   end
 
   def update
-    @item = Item.find(params[:id])
+    @item = GroceryListItem.find(params[:id])
     if @item.update(item_params)
       render json: @item
     else
@@ -32,15 +32,15 @@ class ItemsController < ApplicationController
 
   def destroy
     @list = List.find(params[:list_id])
-    @item = Item.find(params[:id])
+    @item = GroceryListItem.find(params[:id])
     @item.archive
-    redirect_to @list, notice: "Your item was successfully deleted"
+    redirect_to list_url(@list.id), notice: "Your item was successfully deleted"
   end
 
   private
 
   def item_params
-    params.require(:item).permit(
+    params.require(:grocery_list_item).permit(
       :user_id, :name, :list_id, :quantity, :purchased, :quantity_name,
       :refreshed
     )

--- a/app/models/book_list.rb
+++ b/app/models/book_list.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# no doc
+class BookList < List
+  has_many :book_list_items, dependent: :destroy
+end

--- a/app/models/book_list_item.rb
+++ b/app/models/book_list_item.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# no doc
+class BookListItem < ApplicationRecord
+  belongs_to :user
+  belongs_to :book_list
+end

--- a/app/models/grocery_list.rb
+++ b/app/models/grocery_list.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# no doc
+class GroceryList < List
+  has_many :grocery_list_items, dependent: :destroy
+end

--- a/app/models/grocery_list_item.rb
+++ b/app/models/grocery_list_item.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# no doc
+class GroceryListItem < ApplicationRecord
+  belongs_to :user
+  belongs_to :grocery_list
+
+  scope :not_purchased, (-> { where(purchased: false) })
+  scope :purchased, (-> { where(purchased: true) })
+  scope :not_archived, (-> { where(archived_at: nil) })
+  scope :not_refreshed, (-> { where(refreshed: false) })
+  scope :refreshed, (-> { where(refreshed: true) })
+
+  validates :user, :grocery_list, :name, :quantity, presence: true
+  validates :purchased, inclusion: { in: [true, false] }
+
+  def self.ordered
+    all.order(:name)
+  end
+
+  def self.unique_names
+    ordered.select(:name).distinct
+  end
+
+  def archive
+    update archived_at: Time.zone.now
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,27 +2,7 @@
 
 # no doc
 class Item < ApplicationRecord
-  belongs_to :user
-  belongs_to :list
-
-  scope :not_purchased, (-> { where(purchased: false) })
-  scope :purchased, (-> { where(purchased: true) })
-  scope :not_archived, (-> { where(archived_at: nil) })
-  scope :not_refreshed, (-> { where(refreshed: false) })
-  scope :refreshed, (-> { where(refreshed: true) })
-
-  validates :user, :list, :name, :quantity, presence: true
-  validates :purchased, inclusion: { in: [true, false] }
-
-  def self.ordered
-    all.order(:name)
-  end
-
-  def self.unique_names
-    ordered.select(:name).distinct
-  end
-
-  def archive
-    update archived_at: Time.zone.now
-  end
+  # renamed to GroceryListItem
+  # need to keep for migrations if db is dropped
+  # DO NOT USE THIS
 end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -4,7 +4,6 @@
 class List < ApplicationRecord
   has_many :users_lists, dependent: :destroy
   has_many :users, through: :users_lists, source: :user, dependent: :destroy
-  has_many :items, dependent: :destroy
 
   scope :descending, (-> { order(created_at: :desc) })
   scope :not_archived, (-> { where(archived_at: nil) })

--- a/app/models/music_list.rb
+++ b/app/models/music_list.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# no doc
+class MusicList < List
+  has_many :music_list_items, dependent: :destroy
+end

--- a/app/models/music_list_item.rb
+++ b/app/models/music_list_item.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# no doc
+class MusicListItem < ApplicationRecord
+  belongs_to :user
+  belongs_to :music_list
+end

--- a/app/models/to_do_list.rb
+++ b/app/models/to_do_list.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# no doc
+class ToDoList < List
+  has_many :to_do_list_items, dependent: :destroy
+end

--- a/app/models/to_do_list_item.rb
+++ b/app/models/to_do_list_item.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# no doc
+class ToDoListItem < ApplicationRecord
+  belongs_to :user
+  belongs_to :to_do_list
+  belongs_to :assignee, class_name: "User"
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,6 @@ class User < ApplicationRecord
 
   has_many :users_lists, dependent: :destroy
   has_many :lists, through: :users_lists, source: :list, dependent: :destroy
-  has_many :items, through: :lists, dependent: :destroy
   has_many :invitations, class_name: to_s, as: :invited_by
 
   validates :email, presence: true

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,8 @@
 machine:
   node:
-    version: v8.4.0
+    version: v8.5.0
   yarn:
-    version: 1.0.2
+    version: 1.1.0
   ruby:
     version: 2.3.0
 

--- a/client/app/bundles/Groceries/components/AppRouter.jsx
+++ b/client/app/bundles/Groceries/components/AppRouter.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 
-import EditItemForm from './EditItemForm';
+import EditGroceryListItemForm from './EditGroceryListItemForm';
 import ListContainer from './ListContainer';
 import ListEditForm from './ListEditForm';
 import ListsContainer from './ListsContainer';
@@ -27,7 +27,11 @@ export default function AppRouter() {
         <Route exact path="/lists" component={ListsContainer} />
         <Route exact path="/lists/:id" component={ListContainer} />
         <Route exact path="/lists/:id/edit" component={ListEditForm} />
-        <Route exact path="/lists/:list_id/items/:id/edit" component={EditItemForm} />
+        <Route
+          exact
+          path="/lists/:grocery_list_id/grocery_list_items/:id/edit"
+          component={EditGroceryListItemForm}
+        />
         <Route exact path="/lists/:list_id/users_lists/new" component={ShareListForm} />
       </div>
     </Router>

--- a/client/app/bundles/Groceries/components/EditGroceryListItemForm.jsx
+++ b/client/app/bundles/Groceries/components/EditGroceryListItemForm.jsx
@@ -4,10 +4,9 @@ import PropTypes from 'prop-types';
 
 import Alert from './Alert';
 
-export default class EditItemForm extends Component {
+export default class EditGroceryListItemForm extends Component {
   static propTypes = {
     userId: PropTypes.number.isRequired,
-    listId: PropTypes.number.isRequired,
     itemId: PropTypes.number.isRequired,
     itemName: PropTypes.string.isRequired,
     itemQuantity: PropTypes.number.isRequired,
@@ -16,7 +15,7 @@ export default class EditItemForm extends Component {
     match: PropTypes.shape({
       params: PropTypes.shape({
         id: PropTypes.string,
-        list_id: PropTypes.string,
+        grocery_list_id: PropTypes.string,
       }).isRequired,
     }).isRequired,
     history: PropTypes.shape({
@@ -26,7 +25,7 @@ export default class EditItemForm extends Component {
 
   static defaultProps = {
     userId: 0,
-    listId: 0,
+    listId: '0',
     itemId: 0,
     itemName: '',
     itemQuantity: 0,
@@ -38,7 +37,7 @@ export default class EditItemForm extends Component {
     super(props);
     this.state = {
       userId: props.userId,
-      listId: props.listId,
+      listId: props.match.params.grocery_list_id,
       itemId: props.itemId,
       itemName: props.itemName,
       itemPurchased: props.itemPurchased,
@@ -52,13 +51,13 @@ export default class EditItemForm extends Component {
     if (this.props.match) {
       $.ajax({
         type: 'GET',
-        url: `/lists/${this.props.match.params.list_id}` +
-             `/items/${this.props.match.params.id}/edit`,
+        url: `/lists/${this.props.match.params.grocery_list_id}` +
+             `/grocery_list_items/${this.props.match.params.id}/edit`,
         dataType: 'JSON',
       }).done((item) => {
         this.setState({
           userId: item.user_id,
-          listId: item.list_id,
+          listId: item.grocery_list_id,
           itemId: item.id,
           itemName: item.name,
           itemPurchased: item.purchased,
@@ -78,18 +77,18 @@ export default class EditItemForm extends Component {
 
   handleSubmit = (event) => {
     event.preventDefault();
-    const item = {
+    const groceryListItem = {
       user_id: this.state.userId,
       name: this.state.itemName,
-      list_id: this.state.listId,
+      grocery_list_id: this.state.listId,
       quantity: this.state.itemQuantity,
       purchased: this.state.itemPurchased,
       quantity_name: this.state.itemQuantityName,
     };
     // TODO: update to use axios. this will require auth token stuff
     $.ajax({
-      url: `/lists/${this.state.listId}/items/${this.state.itemId}`,
-      data: { item },
+      url: `/lists/${this.state.listId}/grocery_list_items/${this.state.itemId}`,
+      data: { grocery_list_item: groceryListItem },
       method: 'PUT',
     }).done(() => {
       this.props.history.push(`/lists/${this.state.listId}`);

--- a/client/app/bundles/Groceries/components/GroceryListItemForm.jsx
+++ b/client/app/bundles/Groceries/components/GroceryListItemForm.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import Alert from './Alert';
 
-export default class ItemForm extends Component {
+export default class GroceryListItemForm extends Component {
   static propTypes = {
     userId: PropTypes.number.isRequired,
     listId: PropTypes.number.isRequired,
@@ -31,15 +31,18 @@ export default class ItemForm extends Component {
 
   handleSubmit = (event) => {
     event.preventDefault();
-    const item = {
+    const groceryListItem = {
       user_id: this.props.userId,
       name: this.state.name,
-      list_id: this.props.listId,
+      grocery_list_id: this.props.listId,
       quantity: this.state.quantity,
       purchased: this.state.purchased,
       quantity_name: this.state.quantityName,
     };
-    $.post(`/lists/${this.props.listId}/items`, { item }).done((data) => {
+    $.post(
+      `/lists/${this.props.listId}/grocery_list_items`,
+      { grocery_list_item: groceryListItem },
+    ).done((data) => {
       this.props.handleItemAddition(data);
       this.setState({
         name: '',

--- a/client/app/bundles/Groceries/components/GroceryListItemsContainer.jsx
+++ b/client/app/bundles/Groceries/components/GroceryListItemsContainer.jsx
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import NotPurchasedItems from './NotPurchasedItems';
-import PurchasedItems from './PurchasedItems';
+import NotPurchasedGroceryListItems from './NotPurchasedGroceryListItems';
+import PurchasedGroceryListItems from './PurchasedGroceryListItems';
 
-export default class ItemsContainer extends Component {
+export default class GroceryListItemsContainer extends Component {
   static propTypes = {
     handleItemDelete: PropTypes.func.isRequired,
     handlePurchaseOfItem: PropTypes.func.isRequired,
@@ -42,13 +42,13 @@ export default class ItemsContainer extends Component {
     return (
       <div>
         <h2>Items</h2>
-        <NotPurchasedItems
+        <NotPurchasedGroceryListItems
           items={this.props.notPurchasedItems}
           onItemPurchase={this.handlePurchase}
           onItemDelete={this.handleDeletion}
         />
         <br />
-        <PurchasedItems
+        <PurchasedGroceryListItems
           items={this.props.purchasedItems}
           handleItemUnPurchase={this.onItemUnPurchase}
           onItemDelete={this.handleDeletion}

--- a/client/app/bundles/Groceries/components/ListContainer.jsx
+++ b/client/app/bundles/Groceries/components/ListContainer.jsx
@@ -3,8 +3,8 @@ import { Link } from 'react-router-dom';
 import update from 'immutability-helper';
 import PropTypes from 'prop-types';
 
-import ItemForm from './ItemForm';
-import ItemsContainer from './ItemsContainer';
+import GroceryListItemForm from './GroceryListItemForm';
+import GroceryListItemsContainer from './GroceryListItemsContainer';
 
 export default class ListContainer extends Component {
   static propTypes = {
@@ -91,9 +91,9 @@ export default class ListContainer extends Component {
 
   handleItemPurchase = (item) => {
     $.ajax({
-      url: `/lists/${item.list_id}/items/${item.id}`,
+      url: `/lists/${item.list_id}/grocery_list_items/${item.id}`,
       type: 'PUT',
-      data: 'item%5Bpurchased%5D=true',
+      data: 'grocery_list_item%5Bpurchased%5D=true',
       success: () => this.moveItemToPurchased(item),
     });
   }
@@ -102,17 +102,20 @@ export default class ListContainer extends Component {
     const newItem = {
       user_id: item.user_id,
       name: item.name,
-      list_id: item.list_id,
+      grocery_list_id: item.grocery_list_id,
       quantity: item.quantity,
       purchased: false,
       quantity_name: item.quantity_name,
     };
-    $.post(`/lists/${newItem.list_id}/items`, { item: newItem }).done((data) => {
+    $.post(
+      `/lists/${newItem.grocery_list_id}/grocery_list_items`,
+      { grocery_list_item: newItem },
+    ).done((data) => {
       this.handleAddItem(data);
       $.ajax({
-        url: `/lists/${item.list_id}/items/${item.id}`,
+        url: `/lists/${item.grocery_list_id}/grocery_list_items/${item.id}`,
         type: 'PUT',
-        data: 'item%5Brefreshed%5D=true',
+        data: 'grocery_list_item%5Brefreshed%5D=true',
         success: () => this.removeItemFromPurchased(item),
       });
     }).fail((response) => {
@@ -143,7 +146,7 @@ export default class ListContainer extends Component {
     // eslint-disable-next-line no-alert
     if (window.confirm('Are you sure?')) {
       $.ajax({
-        url: `/lists/${item.list_id}/items/${item.id}`,
+        url: `/lists/${item.grocery_list_id}/grocery_list_items/${item.id}`,
         type: 'DELETE',
         success: () => this.removeItem(item.id),
       });
@@ -171,13 +174,13 @@ export default class ListContainer extends Component {
         <h1>{ this.state.list.name }</h1>
         <Link to="/lists" className="pull-right">Back to lists</Link>
         <br />
-        <ItemForm
+        <GroceryListItemForm
           listId={this.state.list.id}
           userId={this.state.userId}
           handleItemAddition={this.handleAddItem}
         />
         <br />
-        <ItemsContainer
+        <GroceryListItemsContainer
           notPurchasedItems={this.state.notPurchasedItems}
           purchasedItems={this.state.purchasedItems}
           handlePurchaseOfItem={this.handleItemPurchase}

--- a/client/app/bundles/Groceries/components/NotPurchasedGroceryListItem.jsx
+++ b/client/app/bundles/Groceries/components/NotPurchasedGroceryListItem.jsx
@@ -2,11 +2,11 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
-export default class NotPurchasedItem extends Component {
+export default class NotPurchasedGroceryListItem extends Component {
   static propTypes = {
     item: PropTypes.shape({
       id: PropTypes.number.isRequired,
-      list_id: PropTypes.number.isRequired,
+      grocery_list_id: PropTypes.number.isRequired,
       name: PropTypes.string.isRequired,
       quantity: PropTypes.number.isRequired,
       quantity_name: PropTypes.string,
@@ -38,7 +38,8 @@ export default class NotPurchasedItem extends Component {
             role="presentation"
           />
           <Link
-            to={`/lists/${this.props.item.list_id}/items/${this.props.item.id}/edit`}
+            to={`/lists/${this.props.item.grocery_list_id}/grocery_list_items` +
+                `/${this.props.item.id}/edit`}
             className="fa fa-pencil-square-o fa-2x text-warning router-link"
             style={{ marginRight: '1rem' }}
           />

--- a/client/app/bundles/Groceries/components/NotPurchasedGroceryListItems.jsx
+++ b/client/app/bundles/Groceries/components/NotPurchasedGroceryListItems.jsx
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import NotPurchasedItem from './NotPurchasedItem';
+import NotPurchasedGroceryListItem from './NotPurchasedGroceryListItem';
 
-export default class NotPurchasedItems extends Component {
+export default class NotPurchasedGroceryListItems extends Component {
   static propTypes = {
     items: PropTypes.arrayOf(
       PropTypes.shape({
@@ -34,7 +34,7 @@ export default class NotPurchasedItems extends Component {
       <div className="list-group">
         {
           this.props.items.map((item, index) => (
-            <NotPurchasedItem
+            <NotPurchasedGroceryListItem
               item={item}
               index={index}
               key={item.id}

--- a/client/app/bundles/Groceries/components/PurchasedGroceryListItem.jsx
+++ b/client/app/bundles/Groceries/components/PurchasedGroceryListItem.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-export default class PurchasedItem extends Component {
+export default class PurchasedGroceryListItem extends Component {
   static propTypes = {
     item: PropTypes.shape({
       id: PropTypes.number.isRequired,

--- a/client/app/bundles/Groceries/components/PurchasedGroceryListItems.jsx
+++ b/client/app/bundles/Groceries/components/PurchasedGroceryListItems.jsx
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import PurchasedItem from './PurchasedItem';
+import PurchasedGroceryListItem from './PurchasedGroceryListItem';
 
-export default class PurchasedItems extends Component {
+export default class PurchasedGroceryListItems extends Component {
   static propTypes = {
     items: PropTypes.arrayOf(
       PropTypes.shape({
@@ -36,7 +36,7 @@ export default class PurchasedItems extends Component {
         <ul className="list-group">
           {
             this.props.items.map(item => (
-              <PurchasedItem
+              <PurchasedGroceryListItem
                 item={item}
                 key={item.id}
                 unPurchaseItem={this.handleUnPurchase}

--- a/client/package.json
+++ b/client/package.json
@@ -2,9 +2,9 @@
   "name": "groceries",
   "private": true,
   "engines": {
-    "node": "8.4.0",
+    "node": "8.5.0",
     "npm": "4.4.4",
-    "yarn": "1.0.2"
+    "yarn": "1.1.0"
   },
   "scripts": {
     "build:test": "NODE_ENV=test webpack --config webpack.config.js",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   end
   resources :lists, only: [:index, :show, :create, :edit, :update, :destroy] do
     post :refresh_list, on: :member
-    resources :items, only: [:create, :edit, :update, :destroy]
+    resources :grocery_list_items, only: [:create, :edit, :update, :destroy]
     resources :users_lists, only: [:new, :create] do
       get :accept_list, on: :collection
       get :reject_list, on: :collection

--- a/db/migrate/20170907010507_add_type_to_lists.rb
+++ b/db/migrate/20170907010507_add_type_to_lists.rb
@@ -1,0 +1,6 @@
+class AddTypeToLists < ActiveRecord::Migration[5.0]
+  def change
+    add_column :lists, :type, :string
+    List.find_each { |list| list.update!(type: "GroceryList") }
+  end
+end

--- a/db/migrate/20170907015215_rename_items_to_grocery_list_items.rb
+++ b/db/migrate/20170907015215_rename_items_to_grocery_list_items.rb
@@ -1,0 +1,15 @@
+class RenameItemsToGroceryListItems < ActiveRecord::Migration[5.0]
+  def self.up
+    remove_index :items, :list_id
+    rename_column :items, :list_id, :grocery_list_id
+    rename_table :items, :grocery_list_items
+    add_index :grocery_list_items, :grocery_list_id
+  end
+
+  def self.down
+    remove_index :grocery_list_items, :grocery_list_id
+    rename_column :grocery_list_items, :grocery_list_id, :list_id
+    rename_table :grocery_list_items, :items
+    add_index :items, :list_id
+  end
+end

--- a/db/migrate/20170924193529_create_book_list_items.rb
+++ b/db/migrate/20170924193529_create_book_list_items.rb
@@ -1,0 +1,27 @@
+class CreateBookListItems < ActiveRecord::Migration[5.0]
+  def change
+    create_table :book_list_items do |t|
+      t.references :user, foreign_key: true, null: false
+      t.references :lists, foreign_key: true, null: false
+      t.string :author
+      t.string :title
+      t.boolean :purchase, null: false, default: false
+      t.boolean :read, null: false, default: false
+      t.datetime :archived_at
+
+      t.timestamps
+    end
+  end
+
+  def self.up
+    remove_index :book_list_items, :list_id
+    rename_column :book_list_items, :list_id, :book_list_id
+    add_index :book_list_items, :book_list_id
+  end
+
+  def self.down
+    remove_index :book_list_items, :book_list_id
+    rename_column :book_list_items, :book_list_id, :list_id
+    add_index :book_list_items, :list_id
+  end
+end

--- a/db/migrate/20170924193540_create_music_list_items.rb
+++ b/db/migrate/20170924193540_create_music_list_items.rb
@@ -1,0 +1,27 @@
+class CreateMusicListItems < ActiveRecord::Migration[5.0]
+  def change
+    create_table :music_list_items do |t|
+      t.references :user, foreign_key: true, null: false
+      t.references :lists, foreign_key: true, null: false
+      t.string :title
+      t.string :artist
+      t.string :album
+      t.boolean :purchased, null: false, default: false
+      t.datetime :archived_at
+
+      t.timestamps
+    end
+  end
+
+  def self.up
+    remove_index :music_list_items, :list_id
+    rename_column :music_list_items, :list_id, :music_list_id
+    add_index :music_list_items, :music_list_id
+  end
+
+  def self.down
+    remove_index :music_list_items, :music_list_id
+    rename_column :music_list_items, :music_list_id, :list_id
+    add_index :music_list_items, :list_id
+  end
+end

--- a/db/migrate/20170924193548_create_to_do_list_items.rb
+++ b/db/migrate/20170924193548_create_to_do_list_items.rb
@@ -1,0 +1,30 @@
+class CreateToDoListItems < ActiveRecord::Migration[5.0]
+  def change
+    create_table :to_do_list_items do |t|
+      t.references :user, foreign_key: true, null: false
+      t.references :lists, foreign_key: true, null: false
+      t.string :name
+      t.references :assignee
+      t.datetime :due_by
+      t.boolean :completed, null: false, default: false
+      t.boolean :refreshed, null: false, default: false
+      t.datetime :archived_at
+
+      t.timestamps
+    end
+
+    add_foreign_key :to_do_list_items, :users, column: :assignee_id, primary_key: :id
+  end
+
+  def self.up
+    remove_index :to_do_list_items, :list_id
+    rename_column :to_do_list_items, :list_id, :to_do_list_id
+    add_index :to_do_list_items, :to_do_list_id
+  end
+
+  def self.down
+    remove_index :to_do_list_items, :to_do_list_id
+    rename_column :to_do_list_items, :to_do_list_id, :list_id
+    add_index :to_do_list_items, :list_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,24 +10,38 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170902190352) do
+ActiveRecord::Schema.define(version: 20170924193548) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "items", force: :cascade do |t|
-    t.integer  "user_id",                       null: false
-    t.integer  "list_id",                       null: false
-    t.string   "name",                          null: false
-    t.integer  "quantity",      default: 1,     null: false
-    t.boolean  "purchased",     default: false, null: false
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+  create_table "book_list_items", force: :cascade do |t|
+    t.integer  "user_id",                     null: false
+    t.integer  "lists_id",                    null: false
+    t.string   "author"
+    t.string   "title"
+    t.boolean  "purchase",    default: false, null: false
+    t.boolean  "read",        default: false, null: false
+    t.datetime "archived_at"
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.index ["lists_id"], name: "index_book_list_items_on_lists_id", using: :btree
+    t.index ["user_id"], name: "index_book_list_items_on_user_id", using: :btree
+  end
+
+  create_table "grocery_list_items", force: :cascade do |t|
+    t.integer  "user_id",                         null: false
+    t.integer  "grocery_list_id",                 null: false
+    t.string   "name",                            null: false
+    t.integer  "quantity",        default: 1,     null: false
+    t.boolean  "purchased",       default: false, null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
     t.string   "quantity_name"
     t.datetime "archived_at"
-    t.boolean  "refreshed",     default: false, null: false
-    t.index ["list_id"], name: "index_items_on_list_id", using: :btree
-    t.index ["user_id"], name: "index_items_on_user_id", using: :btree
+    t.boolean  "refreshed",       default: false, null: false
+    t.index ["grocery_list_id"], name: "index_grocery_list_items_on_grocery_list_id", using: :btree
+    t.index ["user_id"], name: "index_grocery_list_items_on_user_id", using: :btree
   end
 
   create_table "lists", force: :cascade do |t|
@@ -37,6 +51,37 @@ ActiveRecord::Schema.define(version: 20170902190352) do
     t.datetime "archived_at"
     t.boolean  "completed",   default: false, null: false
     t.boolean  "refreshed",   default: false, null: false
+    t.string   "type"
+  end
+
+  create_table "music_list_items", force: :cascade do |t|
+    t.integer  "user_id",                     null: false
+    t.integer  "lists_id",                    null: false
+    t.string   "title"
+    t.string   "artist"
+    t.string   "album"
+    t.boolean  "purchased",   default: false, null: false
+    t.datetime "archived_at"
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.index ["lists_id"], name: "index_music_list_items_on_lists_id", using: :btree
+    t.index ["user_id"], name: "index_music_list_items_on_user_id", using: :btree
+  end
+
+  create_table "to_do_list_items", force: :cascade do |t|
+    t.integer  "user_id",                     null: false
+    t.integer  "lists_id",                    null: false
+    t.string   "name"
+    t.integer  "assignee_id"
+    t.datetime "due_by"
+    t.boolean  "completed",   default: false, null: false
+    t.boolean  "refreshed",   default: false, null: false
+    t.datetime "archived_at"
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.index ["assignee_id"], name: "index_to_do_list_items_on_assignee_id", using: :btree
+    t.index ["lists_id"], name: "index_to_do_list_items_on_lists_id", using: :btree
+    t.index ["user_id"], name: "index_to_do_list_items_on_user_id", using: :btree
   end
 
   create_table "users", force: :cascade do |t|
@@ -77,6 +122,13 @@ ActiveRecord::Schema.define(version: 20170902190352) do
     t.index ["user_id"], name: "index_users_lists_on_user_id", using: :btree
   end
 
-  add_foreign_key "items", "lists"
-  add_foreign_key "items", "users"
+  add_foreign_key "book_list_items", "lists", column: "lists_id"
+  add_foreign_key "book_list_items", "users"
+  add_foreign_key "grocery_list_items", "lists", column: "grocery_list_id"
+  add_foreign_key "grocery_list_items", "users"
+  add_foreign_key "music_list_items", "lists", column: "lists_id"
+  add_foreign_key "music_list_items", "users"
+  add_foreign_key "to_do_list_items", "lists", column: "lists_id"
+  add_foreign_key "to_do_list_items", "users"
+  add_foreign_key "to_do_list_items", "users", column: "assignee_id"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@ user_emails.each do |email|
 end
 
 list_names = %w(foobar foobaz)
-list_names.each { |list| List.create!(name: list) }
+list_names.each { |list| GroceryList.create!(name: list) }
 
 UsersList.create!(
   user: User.find_by(email: 'foo@ex.co'),
@@ -37,9 +37,9 @@ UsersList.create!(
 item_names = %w(apples bananas oranges chocolate beer)
 
 item_names.each do |item|
-  Item.create!(
+  GroceryListItem.create!(
     user: User.find_by(email: 'foo@ex.co'),
-    list: List.find_by(name: 'foobar'),
+    grocery_list: List.find_by(name: 'foobar'),
     name: item,
     quantity: (1..10).to_a.sample,
     quantity_name: %w(bag bunch case).sample

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "groceries",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "yarn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.1.0.tgz",
+      "integrity": "sha1-8tqTQEkCNrbFbeMFscIaihnEM8M="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,11 +2,13 @@
   "name": "groceries",
   "private": true,
   "engines": {
-    "node": "8.4.0",
+    "node": "8.5.0",
     "npm": "4.4.4",
-    "yarn": "1.0.2"
+    "yarn": "1.1.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "yarn": "^1.1.0"
+  },
   "scripts": {
     "postinstall": "cd client && yarn install"
   },

--- a/spec/controllers/grocery_list_items_controller_spec.rb
+++ b/spec/controllers/grocery_list_items_controller_spec.rb
@@ -2,10 +2,11 @@
 
 require "rails_helper"
 
-RSpec.describe ItemsController do
-  let(:user) { create :user_with_lists }
-  let(:list) { user.lists.last }
-  let(:item) { create :item, list: list }
+RSpec.describe GroceryListItemsController do
+  let(:user) { create :user }
+  let(:list) { create :grocery_list }
+  let(:users_list) { create :users_list, user: user, list: list }
+  let(:item) { create :grocery_list_item, grocery_list: list }
 
   before { sign_in user }
 
@@ -32,7 +33,7 @@ RSpec.describe ItemsController do
         expect(JSON.parse(response.body).to_h).to include(
           "archived_at" => item[:archived_at],
           "id" => item[:id],
-          "list_id" => item[:list_id],
+          "grocery_list_id" => item[:grocery_list_id],
           "name" => item[:name],
           "purchased" => item[:purchased],
           "quantity" => item[:quantity],
@@ -49,20 +50,24 @@ RSpec.describe ItemsController do
       it "creates a new item" do
         expect do
           post :create, params: {
-            item: {
+            grocery_list_item: {
+              grocery_list_id: list.id,
               user_id: user.id,
               name: "foo"
             },
             list_id: list.id
           }
-        end.to change(Item, :count).by 1
+        end.to change(GroceryListItem, :count).by 1
       end
     end
 
     describe "with invalid params" do
       it "returns 422" do
         post :create, params: {
-          item: { name: nil },
+          grocery_list_item: {
+            grocery_list_id: list.id,
+            name: nil
+          },
           list_id: list.id
         }
 
@@ -74,10 +79,10 @@ RSpec.describe ItemsController do
   describe "PUT #update" do
     describe "with valid params" do
       it "updates a item" do
-        update_item = create :item, name: "foo"
+        update_item = create :grocery_list_item, name: "foo"
         put :update, params: {
           id: update_item.id,
-          item: { name: "bar" },
+          grocery_list_item: { name: "bar" },
           list_id: list.id
         }
         update_item.reload
@@ -88,10 +93,10 @@ RSpec.describe ItemsController do
 
     describe "with invalid params" do
       it "returns 422" do
-        item = create :item
+        item = create :grocery_list_item
         put :update, params: {
           id: item.id,
-          item: { name: nil },
+          grocery_list_item: { name: nil },
           list_id: list.id
         }
 
@@ -102,13 +107,13 @@ RSpec.describe ItemsController do
 
   describe "DELETE #destroy" do
     it "destroys a item" do
-      delete_item = create :item, name: "foo"
+      delete_item = create :grocery_list_item, name: "foo"
       delete :destroy, params: {
         id: delete_item.id,
         list_id: list.id
       }
 
-      expect(Item.not_archived).to_not include delete_item
+      expect(GroceryListItem.not_archived).to_not include delete_item
     end
   end
 end

--- a/spec/controllers/lists_controller_spec.rb
+++ b/spec/controllers/lists_controller_spec.rb
@@ -149,9 +149,10 @@ RSpec.describe ListsController do
     end
 
     it "creates new items" do
-      Item.create!(
+      list = GroceryList.create!(name: "NewGroceryList")
+      GroceryListItem.create!(
         user: user,
-        list: list,
+        grocery_list: list,
         name: "foo",
         quantity: 1,
         quantity_name: "bar"
@@ -160,7 +161,7 @@ RSpec.describe ListsController do
         post :refresh_list, params: {
           id: list.id
         }
-      end.to change(Item, :count).by 1
+      end.to change(GroceryListItem, :count).by 1
     end
   end
 end

--- a/spec/factories/book_list_items.rb
+++ b/spec/factories/book_list_items.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :book_list_item do
+    user nil
+    book_lists nil
+    author "MyString"
+    title "MyString"
+    purchase false
+    read false
+    archived_at "2017-09-24 14:35:29"
+  end
+end

--- a/spec/factories/grocery_list_items.rb
+++ b/spec/factories/grocery_list_items.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 FactoryGirl.define do
-  factory :item do
+  factory :grocery_list_item do
     user
-    list
+    grocery_list
     name "MyString"
     quantity 1
     purchased false

--- a/spec/factories/grocery_lists.rb
+++ b/spec/factories/grocery_lists.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :grocery_list do
+    sequence(:name) { |n| "MyString#{n}" }
+    type "GroceryList"
+  end
+end

--- a/spec/factories/music_list_items.rb
+++ b/spec/factories/music_list_items.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :music_list_item do
+    user nil
+    music_list nil
+    title "MyString"
+    artist "MyString"
+    album "MyString"
+    purchased false
+    archived_at "2017-09-24 14:35:40"
+  end
+end

--- a/spec/factories/to_do_list_items.rb
+++ b/spec/factories/to_do_list_items.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :to_do_list_item do
+    user nil
+    to_do_list nil
+    name "MyString"
+    assignee nil
+    due_by "2017-09-24 14:35:48"
+    completed false
+    refreshed false
+    archived_at "2017-09-24 14:35:48"
+  end
+end

--- a/spec/features/grocery_list_items_spec.rb
+++ b/spec/features/grocery_list_items_spec.rb
@@ -2,11 +2,12 @@
 
 require "rails_helper"
 
-feature "Items", :js do
-  let(:user) { create :user_with_lists }
-  let(:list) { user.lists.last }
+feature "Grocery List Items", :js do
+  let(:user) { create :user }
+  let(:list) { create :grocery_list }
+  let(:users_list) { create :users_list, user: user, list: list }
   let(:list_page) { Pages::List.new }
-  let(:item_page) { Pages::Item.new }
+  let(:item_page) { Pages::GroceryListItem.new }
 
   before do
     log_in_user user
@@ -28,7 +29,9 @@ feature "Items", :js do
   end
 
   describe "update" do
-    let(:item) { create :item, list: list, name: "bar", quantity: 10 }
+    let(:item) do
+      create :grocery_list_item, grocery_list: list, name: "bar", quantity: 10
+    end
 
     before do
       item_page.load_edit(item, list)
@@ -53,7 +56,7 @@ feature "Items", :js do
 
   describe "destroy" do
     before do
-      create :item, list: list, name: "bar"
+      create :grocery_list_item, list: list, name: "bar"
       list_page.load_list list
     end
 

--- a/spec/features/list_spec.rb
+++ b/spec/features/list_spec.rb
@@ -6,7 +6,7 @@ feature "Lists", :js do
   let(:user) { create :user_with_lists }
   let(:another_user) { create :user_with_lists }
   let!(:first_list) { create :list, name: "foo" }
-  let!(:second_list) { create :list, name: "bar" }
+  let!(:second_list) { create :grocery_list, name: "bar" }
   let!(:third_list) { create :list, name: "baz" }
   let!(:fourth) { create :list, name: "asdf" }
   let!(:fifth) { create :list, name: "xyz" }
@@ -77,7 +77,7 @@ feature "Lists", :js do
       let(:list) { List.find_by(name: "bar") }
 
       before do
-        create :item, list: list
+        create :grocery_list_item, grocery_list: list
         list_page.load_index
       end
 

--- a/spec/models/book_list_item_spec.rb
+++ b/spec/models/book_list_item_spec.rb
@@ -2,6 +2,6 @@
 
 require "rails_helper"
 
-RSpec.describe Item do
+RSpec.describe BookListItem, type: :model do
   # nothing here
 end

--- a/spec/models/book_list_spec.rb
+++ b/spec/models/book_list_spec.rb
@@ -2,6 +2,6 @@
 
 require "rails_helper"
 
-RSpec.describe Item do
+RSpec.describe BookList do
   # nothing here
 end

--- a/spec/models/grocery_list_item_spec.rb
+++ b/spec/models/grocery_list_item_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe GroceryListItem do
+  let(:item) { create :grocery_list_item, name: "foo" }
+  let(:another_item) { create :grocery_list_item, name: "bar" }
+
+  describe "validations" do
+    it { expect(item).to be_valid }
+
+    it "is invalid without user" do
+      item.user = nil
+
+      expect(item).to_not be_valid
+    end
+
+    it "is invalid without name" do
+      item.name = nil
+
+      expect(item).to_not be_valid
+    end
+
+    it "is invalid without quantity" do
+      item.quantity = nil
+
+      expect(item).to_not be_valid
+    end
+
+    it "is invalid without purchased" do
+      item.purchased = nil
+
+      expect(item).to_not be_valid
+    end
+  end
+
+  describe ".ordered" do
+    it "returns items ordered by name" do
+      expect(GroceryListItem.ordered).to eq [another_item, item]
+    end
+  end
+
+  describe ".unique_names" do
+    let(:third_item) { create :grocery_list_item, name: "foo" }
+
+    it "returns unique items based on name" do
+      item
+      another_item
+      third_item
+      item_names = GroceryListItem.unique_names.map(&:name)
+      expect(item_names).to eq [another_item.name, item.name]
+    end
+  end
+end

--- a/spec/models/grocery_list_spec.rb
+++ b/spec/models/grocery_list_spec.rb
@@ -2,6 +2,6 @@
 
 require "rails_helper"
 
-RSpec.describe Item do
+RSpec.describe GroceryList do
   # nothing here
 end

--- a/spec/models/music_list_item_spec.rb
+++ b/spec/models/music_list_item_spec.rb
@@ -2,6 +2,6 @@
 
 require "rails_helper"
 
-RSpec.describe Item do
+RSpec.describe MusicListItem, type: :model do
   # nothing here
 end

--- a/spec/models/music_list_spec.rb
+++ b/spec/models/music_list_spec.rb
@@ -2,6 +2,6 @@
 
 require "rails_helper"
 
-RSpec.describe Item do
+RSpec.describe MusicList do
   # nothing here
 end

--- a/spec/models/to_do_list_item_spec.rb
+++ b/spec/models/to_do_list_item_spec.rb
@@ -2,6 +2,6 @@
 
 require "rails_helper"
 
-RSpec.describe Item do
+RSpec.describe ToDoListItem, type: :model do
   # nothing here
 end

--- a/spec/models/to_do_list_spec.rb
+++ b/spec/models/to_do_list_spec.rb
@@ -2,6 +2,6 @@
 
 require "rails_helper"
 
-RSpec.describe Item do
+RSpec.describe ToDoList do
   # nothing here
 end

--- a/spec/support/pages/grocery_list_item.rb
+++ b/spec/support/pages/grocery_list_item.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pages
-  class Item < Page
+  class GroceryListItem < Page
     def fill_in_new_name_with(name)
       fill_in "Add a new item", with: name
     end
@@ -25,7 +25,7 @@ module Pages
     end
 
     def load_edit(item, list)
-      visit edit_list_item_path(item, list_id: list.id)
+      visit edit_list_grocery_list_item_path(item, list_id: list.id)
     end
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,3 +2,6 @@
 # yarn lockfile v1
 
 
+yarn@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.1.0.tgz#f2da9340490236b6c56de305b1c21a8a19c433c3"


### PR DESCRIPTION
This pull request adds the different list types and list items. Lists use STI (single table inheritance), so each model is a `List` with a different attribute `type`. There are no extra tables for lists. The only difference in the models is the association to the various item types. Alternatively, items are different. Each item type has different attributes, and therefore STI does not make sense here, and therefore each item has a different model and table. The model `Item` is left for ease of migration use but do not use this model.