### PR TITLE
Update attributes and inputs so `name` is not involved

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (5.1.0.344)
     nio4r (2.3.1)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     orm_adapter (0.5.0)
     parallel (1.12.1)

--- a/app/controllers/grocery_list_items_controller.rb
+++ b/app/controllers/grocery_list_items_controller.rb
@@ -41,8 +41,8 @@ class GroceryListItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:grocery_list_item).permit(
-      :user_id, :name, :list_id, :quantity, :purchased, :refreshed
-    )
+    params
+      .require(:grocery_list_item)
+      .permit(:user_id, :product, :list_id, :quantity, :purchased, :refreshed)
   end
 end

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -143,7 +143,7 @@ class ListsController < ApplicationController
       ToDoListItem.create!(
         user: current_user,
         to_do_list: new_list,
-        name: item[:name],
+        task: item[:task],
         assignee_id: item[:assignee_id],
         due_by: item[:due_by]
       )
@@ -178,7 +178,7 @@ class ListsController < ApplicationController
       GroceryListItem.create!(
         user: current_user,
         grocery_list: new_list,
-        name: item[:name],
+        product: item[:product],
         quantity: item[:quantity]
       )
     end

--- a/app/controllers/to_do_list_items_controller.rb
+++ b/app/controllers/to_do_list_items_controller.rb
@@ -42,7 +42,7 @@ class ToDoListItemsController < ApplicationController
 
   def item_params
     params.require(:to_do_list_item).permit(
-      :user_id, :list_id, :name, :assignee_id, :due_by, :completed, :refreshed
+      :user_id, :list_id, :task, :assignee_id, :due_by, :completed, :refreshed
     )
   end
 end

--- a/app/models/grocery_list_item.rb
+++ b/app/models/grocery_list_item.rb
@@ -11,15 +11,11 @@ class GroceryListItem < ApplicationRecord
   scope :not_refreshed, (-> { where(refreshed: false) })
   scope :refreshed, (-> { where(refreshed: true) })
 
-  validates :user, :grocery_list, :name, :quantity, presence: true
+  validates :user, :grocery_list, :product, :quantity, presence: true
   validates :purchased, inclusion: { in: [true, false] }
 
   def self.ordered
-    all.order(:name)
-  end
-
-  def self.unique_names
-    ordered.select(:name).distinct
+    all.order(:product)
   end
 
   def archive

--- a/app/models/to_do_list_item.rb
+++ b/app/models/to_do_list_item.rb
@@ -11,11 +11,11 @@ class ToDoListItem < ApplicationRecord
   scope :not_refreshed, (-> { where(refreshed: false) })
   scope :refreshed, (-> { where(refreshed: true) })
 
-  validates :user, :to_do_list, :name, presence: true
+  validates :user, :to_do_list, :task, presence: true
   validates :completed, inclusion: { in: [true, false] }
 
   def self.ordered
-    all.order(:name)
+    all.order(:task)
   end
 
   def archive

--- a/client/app/bundles/Groceries/components/EditListItemForm.jsx
+++ b/client/app/bundles/Groceries/components/EditListItemForm.jsx
@@ -30,7 +30,8 @@ export default class EditListItemForm extends Component {
       listId: 0,
       itemId: 0,
       listType: 'GroceryList',
-      itemName: '',
+      product: '',
+      task: '',
       itemPurchased: false,
       itemQuantity: '',
       itemCompleted: false,
@@ -62,7 +63,8 @@ export default class EditListItemForm extends Component {
           listId: list.id,
           listType: list.type,
           itemId: item.id,
-          itemName: item.name,
+          product: item.product,
+          task: item.task,
           itemPurchased: item.purchased,
           itemQuantity: item.quantity,
           itemCompleted: item.completed,
@@ -92,7 +94,7 @@ export default class EditListItemForm extends Component {
     this.setState(obj);
   }
 
-  listTypetoSnakeCase = listType =>
+  listTypeToSnakeCase = listType =>
     listType.replace(/([A-Z])/g, $1 => `_${$1}`.toLowerCase()).slice(1);
 
   handleSubmit = (event) => {
@@ -102,7 +104,8 @@ export default class EditListItemForm extends Component {
     });
     const listItem = {
       user_id: this.state.userId,
-      name: this.state.itemName,
+      product: this.state.product,
+      task: this.state.task,
       quantity: this.state.itemQuantity,
       purchased: this.state.itemPurchased,
       completed: this.state.itemCompleted,
@@ -114,13 +117,13 @@ export default class EditListItemForm extends Component {
       due_by: this.state.itemDueBy,
       assignee_id: this.state.itemAssigneeId,
     };
-    listItem[`${this.listTypetoSnakeCase(this.state.listType)}_id`] = this.state.listId;
+    listItem[`${this.listTypeToSnakeCase(this.state.listType)}_id`] = this.state.listId;
     const putData = {};
-    putData[`${this.listTypetoSnakeCase(this.state.listType)}_item`] = listItem;
+    putData[`${this.listTypeToSnakeCase(this.state.listType)}_item`] = listItem;
     // TODO: update to use axios. this will require auth token stuff
     $.ajax({
       url: `/lists/${this.state.listId}/` +
-           `${this.listTypetoSnakeCase(this.state.listType)}_items/` +
+           `${this.listTypeToSnakeCase(this.state.listType)}_items/` +
            `${this.state.itemId}`,
       data: putData,
       method: 'PUT',
@@ -139,11 +142,11 @@ export default class EditListItemForm extends Component {
   itemName = () => (
     {
       BookList: `${this.state.itemTitle ? this.prettyTitle() : ''} ${this.state.itemAuthor}`,
-      GroceryList: this.state.itemName,
+      GroceryList: this.state.product,
       MusicList: `${this.state.itemTitle ? this.prettyTitle() : ''} ${this.state.itemArtist} ` +
                  `${this.state.itemArtist && this.state.itemAlbum ? '- ' : ''}` +
                  `${this.state.itemAlbum ? this.state.itemAlbum : ''}`,
-      ToDoList: this.state.itemName,
+      ToDoList: this.state.task,
     }[this.state.listType]
   )
 
@@ -162,7 +165,7 @@ export default class EditListItemForm extends Component {
     } else if (this.state.listType === 'GroceryList') {
       return (
         <GroceryListItemFormFields
-          itemName={this.state.itemName}
+          product={this.state.product}
           itemQuantity={this.state.itemQuantity}
           itemPurchased={this.state.itemPurchased}
           inputHandler={this.handleUserInput}
@@ -183,7 +186,7 @@ export default class EditListItemForm extends Component {
     } else if (this.state.listType === 'ToDoList') {
       return (
         <ToDoListItemFormFields
-          itemName={this.state.itemName}
+          task={this.state.task}
           itemAssigneeId={this.state.itemAssigneeId}
           itemDueBy={this.state.itemDueBy}
           itemCompleted={this.state.itemCompleted}

--- a/client/app/bundles/Groceries/components/GroceryListItemFormFields.jsx
+++ b/client/app/bundles/Groceries/components/GroceryListItemFormFields.jsx
@@ -4,13 +4,13 @@ import PropTypes from 'prop-types';
 const EditGroceryListItemFormFields = props => (
   <div>
     <div className="form-group">
-      <label htmlFor="itemName">Item Name</label>
+      <label htmlFor="product">Product</label>
       <input
-        name="itemName"
+        name="product"
         type="text"
         className="form-control"
-        id="itemName"
-        value={props.itemName}
+        id="product"
+        value={props.product}
         onChange={props.inputHandler}
         placeholder="apples"
       />
@@ -48,7 +48,7 @@ const EditGroceryListItemFormFields = props => (
 );
 
 EditGroceryListItemFormFields.propTypes = {
-  itemName: PropTypes.string.isRequired,
+  product: PropTypes.string.isRequired,
   itemQuantity: PropTypes.string.isRequired,
   itemPurchased: PropTypes.bool,
   inputHandler: PropTypes.func.isRequired,

--- a/client/app/bundles/Groceries/components/ListContainer.jsx
+++ b/client/app/bundles/Groceries/components/ListContainer.jsx
@@ -16,7 +16,8 @@ export default class ListContainer extends Component {
     }),
     not_purchased_items: PropTypes.arrayOf(PropTypes.shape({
       id: PropTypes.number.isRequired,
-      name: PropTypes.string,
+      product: PropTypes.string,
+      task: PropTypes.string,
       quantity: PropTypes.number,
       author: PropTypes.string,
       title: PropTypes.string,
@@ -27,7 +28,8 @@ export default class ListContainer extends Component {
     }).isRequired),
     purchased_items: PropTypes.arrayOf(PropTypes.shape({
       id: PropTypes.number.isRequired,
-      name: PropTypes.string,
+      product: PropTypes.string,
+      task: PropTypes.string,
       quantity: PropTypes.number,
       author: PropTypes.string,
       title: PropTypes.string,
@@ -109,14 +111,14 @@ export default class ListContainer extends Component {
     this.setState({ notPurchasedItems });
   }
 
-  listTypetoSnakeCase = () => {
+  listTypeToSnakeCase = () => {
     const listType = this.state.list.type;
     return listType.replace(/([A-Z])/g, $1 => `_${$1}`.toLowerCase()).slice(1);
   }
 
-  listItemPath = item => `/lists/${this.listId(item)}/${this.listTypetoSnakeCase()}_items`
+  listItemPath = item => `/lists/${this.listId(item)}/${this.listTypeToSnakeCase()}_items`
 
-  listId = item => item[`${this.listTypetoSnakeCase()}_id`]
+  listId = item => item[`${this.listTypeToSnakeCase()}_id`]
 
   handleItemPurchase = (item) => {
     let completionType;
@@ -128,7 +130,7 @@ export default class ListContainer extends Component {
     $.ajax({
       url: `${this.listItemPath(item)}/${item.id}`,
       type: 'PUT',
-      data: `${this.listTypetoSnakeCase()}_item%5B${completionType}%5D=true`,
+      data: `${this.listTypeToSnakeCase()}_item%5B${completionType}%5D=true`,
       success: () => this.moveItemToPurchased(item),
     });
   }
@@ -137,7 +139,7 @@ export default class ListContainer extends Component {
     $.ajax({
       url: `${this.listItemPath(item)}/${item.id}`,
       type: 'PUT',
-      data: `${this.listTypetoSnakeCase()}_item%5Bread%5D=true`,
+      data: `${this.listTypeToSnakeCase()}_item%5Bread%5D=true`,
     });
     // TODO: remove this
     window.location.reload();
@@ -147,7 +149,7 @@ export default class ListContainer extends Component {
     $.ajax({
       url: `${this.listItemPath(item)}/${item.id}`,
       type: 'PUT',
-      data: `${this.listTypetoSnakeCase()}_item%5Bread%5D=false`,
+      data: `${this.listTypeToSnakeCase()}_item%5Bread%5D=false`,
     });
     // TODO: remove this
     window.location.reload();
@@ -156,23 +158,24 @@ export default class ListContainer extends Component {
   handleUnPurchase = (item) => {
     const newItem = {
       user_id: item.user_id,
-      name: item.name,
+      product: item.product,
+      task: item.task,
       quantity: item.quantity,
       purchased: false,
       completed: false,
       assignee_id: item.assignee_id,
       due_by: item.due_by,
     };
-    newItem[`${this.listTypetoSnakeCase()}_id`] = this.listId(item);
+    newItem[`${this.listTypeToSnakeCase()}_id`] = this.listId(item);
     const postData = {};
-    postData[`${this.listTypetoSnakeCase()}_item`] = newItem;
+    postData[`${this.listTypeToSnakeCase()}_item`] = newItem;
     $.post(`${this.listItemPath(newItem)}`, postData)
       .done((data) => {
         this.handleAddItem(data);
         $.ajax({
           url: `${this.listItemPath(item)}/${item.id}`,
           type: 'PUT',
-          data: `${this.listTypetoSnakeCase()}_item%5Brefreshed%5D=true`,
+          data: `${this.listTypeToSnakeCase()}_item%5Brefreshed%5D=true`,
           success: () => this.removeItemFromPurchased(item),
         });
       }).fail((response) => {

--- a/client/app/bundles/Groceries/components/ListForm.jsx
+++ b/client/app/bundles/Groceries/components/ListForm.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 
 import ListTypeOptions from './ListTypeOptions';
 
+const defaultListType = 'GroceryList';
+
 export default class ListForm extends Component {
   static propTypes = {
     onFormSubmit: PropTypes.func.isRequired,
@@ -11,45 +13,44 @@ export default class ListForm extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      listName: '',
-      listType: 'GroceryList',
+      list: '',
+      listType: defaultListType,
     };
   }
 
   handleChange = (event) => {
-    const { name } = event.target;
+    const { name, value } = event.target;
     const obj = {};
-    obj[name] = event.target.value;
+    obj[name] = value;
     this.setState(obj);
   }
 
   handleSubmit = (event) => {
     event.preventDefault();
     this.props.onFormSubmit({
-      name: this.state.listName,
+      name: this.state.list,
       type: this.state.listType,
     });
-    this.setState({ listName: '', listType: 'GroceryList' });
+    this.setState({ list: '', listType: defaultListType });
   }
 
   render() {
     return (
       <form className="form" onSubmit={this.handleSubmit}>
         <div className="form-group">
-          <label htmlFor="listName">Name</label>
+          <label htmlFor="list">Name</label>
           <input
-            name="listName"
+            id="list"
+            name="list"
             type="text"
             className="form-control"
-            value={this.state.listName}
+            value={this.state.list}
             onChange={this.handleChange}
             placeholder="My super cool list"
           />
         </div>
         <ListTypeOptions listType={this.state.listType} changeHandler={this.handleChange} />
-        <button type="submit" className="btn btn-success btn-block">
-          Create List
-        </button>
+        <button type="submit" className="btn btn-success btn-block">Create List</button>
       </form>
     );
   }

--- a/client/app/bundles/Groceries/components/ListItem.jsx
+++ b/client/app/bundles/Groceries/components/ListItem.jsx
@@ -8,7 +8,8 @@ export default class ListItem extends Component {
   static propTypes = {
     item: PropTypes.shape({
       id: PropTypes.number.isRequired,
-      name: PropTypes.string,
+      product: PropTypes.string,
+      task: PropTypes.string,
       quantity: PropTypes.string,
       author: PropTypes.string,
       title: PropTypes.string,
@@ -48,24 +49,24 @@ export default class ListItem extends Component {
 
   prettyTitle = () => `"${this.props.item.title}"`
 
-  listTypetoSnakeCase = () => {
+  listTypeToSnakeCase = () => {
     const { listType } = this.props;
     return listType.replace(/([A-Z])/g, $1 => `_${$1}`.toLowerCase()).slice(1);
   }
 
   listItemPath = () => {
-    const listId = this.props.item[`${this.listTypetoSnakeCase()}_id`];
-    return `/lists/${listId}/${this.listTypetoSnakeCase()}_items`;
+    const listId = this.props.item[`${this.listTypeToSnakeCase()}_id`];
+    return `/lists/${listId}/${this.listTypeToSnakeCase()}_items`;
   }
 
   itemName = () => (
     {
       BookList: `${this.props.item.title ? this.prettyTitle() : ''} ${this.props.item.author}`,
-      GroceryList: `${this.props.item.quantity} ${this.props.item.name}`,
+      GroceryList: `${this.props.item.quantity} ${this.props.item.product}`,
       MusicList: `${this.props.item.title ? this.prettyTitle() : ''} ${this.props.item.artist} ` +
                  `${this.props.item.artist && this.props.item.album ? '- ' : ''}` +
                  `${this.props.item.album ? this.props.item.album : ''}`,
-      ToDoList: `${this.props.item.name}`,
+      ToDoList: `${this.props.item.task}`,
     }[this.props.listType]
   )
 

--- a/client/app/bundles/Groceries/components/ListItemForm.jsx
+++ b/client/app/bundles/Groceries/components/ListItemForm.jsx
@@ -10,7 +10,8 @@ import MusicListItemFormFields from './MusicListItemFormFields';
 import ToDoListItemFormFields from './ToDoListItemFormFields';
 
 const initialState = {
-  itemName: '',
+  product: '',
+  task: '',
   itemQuantity: '',
   itemAuthor: '',
   itemTitle: '',
@@ -44,13 +45,13 @@ export default class ListItemForm extends Component {
   }
 
   handleUserInput = (event) => {
-    const { name } = event.target;
+    const { name, value } = event.target;
     const obj = {};
-    obj[name] = event.target.value;
+    obj[name] = value;
     this.setState(obj);
   }
 
-  listTypetoSnakeCase = () => {
+  listTypeToSnakeCase = () => {
     const { listType } = this.props;
     return listType.replace(/([A-Z])/g, $1 => `_${$1}`.toLowerCase()).slice(1);
   }
@@ -63,7 +64,8 @@ export default class ListItemForm extends Component {
     });
     const listItem = {
       user_id: this.props.userId,
-      name: this.state.itemName,
+      product: this.state.product,
+      task: this.state.task,
       quantity: this.state.itemQuantity,
       author: this.state.itemAuthor,
       title: this.state.itemTitle,
@@ -72,11 +74,11 @@ export default class ListItemForm extends Component {
       assignee_id: this.state.itemAssigneeId,
       due_by: this.state.itemDueBy,
     };
-    listItem[`${this.listTypetoSnakeCase()}_id`] = this.props.listId;
+    listItem[`${this.listTypeToSnakeCase()}_id`] = this.props.listId;
     const postData = {};
-    postData[`${this.listTypetoSnakeCase()}_item`] = listItem;
+    postData[`${this.listTypeToSnakeCase()}_item`] = listItem;
     $.post(
-      `/lists/${this.props.listId}/${this.listTypetoSnakeCase()}_items`,
+      `/lists/${this.props.listId}/${this.listTypeToSnakeCase()}_items`,
       postData,
     ).done((data) => {
       this.props.handleItemAddition(data);
@@ -111,7 +113,7 @@ export default class ListItemForm extends Component {
       return (
         <GroceryListItemFormFields
           itemQuantity={this.state.itemQuantity}
-          itemName={this.state.itemName}
+          product={this.state.product}
           inputHandler={this.handleUserInput}
         />
       );
@@ -127,7 +129,7 @@ export default class ListItemForm extends Component {
     } else if (this.props.listType === 'ToDoList') {
       return (
         <ToDoListItemFormFields
-          itemName={this.state.itemName}
+          task={this.state.task}
           itemAssigneeId={this.state.itemAssigneeId}
           listUsers={this.props.listUsers}
           itemDueBy={this.state.itemDueBy}

--- a/client/app/bundles/Groceries/components/ListItems.jsx
+++ b/client/app/bundles/Groceries/components/ListItems.jsx
@@ -7,7 +7,8 @@ export default class ListItems extends Component {
   static propTypes = {
     items: PropTypes.arrayOf(PropTypes.shape({
       id: PropTypes.number.isRequired,
-      name: PropTypes.string,
+      product: PropTypes.string,
+      task: PropTypes.string,
       quantity: PropTypes.string,
       author: PropTypes.string,
       title: PropTypes.string,

--- a/client/app/bundles/Groceries/components/ListItemsContainer.jsx
+++ b/client/app/bundles/Groceries/components/ListItemsContainer.jsx
@@ -12,7 +12,8 @@ export default class ListItemsContainer extends Component {
     handleItemUnPurchase: PropTypes.func.isRequired,
     notPurchasedItems: PropTypes.arrayOf(PropTypes.shape({
       id: PropTypes.number.isRequired,
-      name: PropTypes.string,
+      product: PropTypes.string,
+      task: PropTypes.string,
       quantity: PropTypes.string,
       author: PropTypes.string,
       title: PropTypes.string,
@@ -23,7 +24,8 @@ export default class ListItemsContainer extends Component {
     }).isRequired).isRequired,
     purchasedItems: PropTypes.arrayOf(PropTypes.shape({
       id: PropTypes.number.isRequired,
-      name: PropTypes.string,
+      product: PropTypes.string,
+      task: PropTypes.string,
       quantity: PropTypes.string,
       author: PropTypes.string,
       title: PropTypes.string,

--- a/client/app/bundles/Groceries/components/ToDoListItemFormFields.jsx
+++ b/client/app/bundles/Groceries/components/ToDoListItemFormFields.jsx
@@ -4,13 +4,13 @@ import PropTypes from 'prop-types';
 const EditToDoListItemFormFields = props => (
   <div>
     <div className="form-group">
-      <label htmlFor="itemName">Name</label>
+      <label htmlFor="task">Task</label>
       <input
-        name="itemName"
+        name="task"
         type="text"
         className="form-control"
-        id="itemName"
-        value={props.itemName}
+        id="task"
+        value={props.task}
         onChange={props.inputHandler}
         placeholder="Clean the toilets"
       />
@@ -65,7 +65,7 @@ const EditToDoListItemFormFields = props => (
 );
 
 EditToDoListItemFormFields.propTypes = {
-  itemName: PropTypes.string.isRequired,
+  task: PropTypes.string.isRequired,
   itemAssigneeId: PropTypes.string.isRequired,
   itemDueBy: PropTypes.string.isRequired,
   itemCompleted: PropTypes.bool,

--- a/db/migrate/20180805203207_change_grocery_list_item_name_to_product.rb
+++ b/db/migrate/20180805203207_change_grocery_list_item_name_to_product.rb
@@ -1,0 +1,5 @@
+class ChangeGroceryListItemNameToProduct < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :grocery_list_items, :name, :product
+  end
+end

--- a/db/migrate/20180805212618_change_to_do_list_item_name_to_task.rb
+++ b/db/migrate/20180805212618_change_to_do_list_item_name_to_task.rb
@@ -1,0 +1,5 @@
+class ChangeToDoListItemNameToTask < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :to_do_list_items, :name, :task
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,115 +10,115 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180604005252) do
+ActiveRecord::Schema.define(version: 2018_08_05_212618) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "book_list_items", force: :cascade do |t|
-    t.integer  "user_id",                      null: false
-    t.integer  "book_list_id",                 null: false
-    t.string   "author"
-    t.string   "title"
-    t.boolean  "purchased",    default: false, null: false
-    t.boolean  "read",         default: false, null: false
+  create_table "book_list_items", id: :serial, force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "book_list_id", null: false
+    t.string "author"
+    t.string "title"
+    t.boolean "purchased", default: false, null: false
+    t.boolean "read", default: false, null: false
     t.datetime "archived_at"
-    t.datetime "created_at",                   null: false
-    t.datetime "updated_at",                   null: false
-    t.index ["book_list_id"], name: "index_book_list_items_on_book_list_id", using: :btree
-    t.index ["user_id"], name: "index_book_list_items_on_user_id", using: :btree
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["book_list_id"], name: "index_book_list_items_on_book_list_id"
+    t.index ["user_id"], name: "index_book_list_items_on_user_id"
   end
 
-  create_table "grocery_list_items", force: :cascade do |t|
-    t.integer  "user_id",                         null: false
-    t.integer  "grocery_list_id",                 null: false
-    t.string   "name",                            null: false
-    t.string   "quantity",        default: "1",   null: false
-    t.boolean  "purchased",       default: false, null: false
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+  create_table "grocery_list_items", id: :serial, force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "grocery_list_id", null: false
+    t.string "product", null: false
+    t.string "quantity", default: "1", null: false
+    t.boolean "purchased", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.datetime "archived_at"
-    t.boolean  "refreshed",       default: false, null: false
-    t.index ["grocery_list_id"], name: "index_grocery_list_items_on_grocery_list_id", using: :btree
-    t.index ["user_id"], name: "index_grocery_list_items_on_user_id", using: :btree
+    t.boolean "refreshed", default: false, null: false
+    t.index ["grocery_list_id"], name: "index_grocery_list_items_on_grocery_list_id"
+    t.index ["user_id"], name: "index_grocery_list_items_on_user_id"
   end
 
-  create_table "lists", force: :cascade do |t|
-    t.string   "name",                        null: false
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+  create_table "lists", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.datetime "archived_at"
-    t.boolean  "completed",   default: false, null: false
-    t.boolean  "refreshed",   default: false, null: false
-    t.string   "type"
+    t.boolean "completed", default: false, null: false
+    t.boolean "refreshed", default: false, null: false
+    t.string "type"
   end
 
-  create_table "music_list_items", force: :cascade do |t|
-    t.integer  "user_id",                       null: false
-    t.integer  "music_list_id",                 null: false
-    t.string   "title"
-    t.string   "artist"
-    t.string   "album"
-    t.boolean  "purchased",     default: false, null: false
+  create_table "music_list_items", id: :serial, force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "music_list_id", null: false
+    t.string "title"
+    t.string "artist"
+    t.string "album"
+    t.boolean "purchased", default: false, null: false
     t.datetime "archived_at"
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
-    t.index ["music_list_id"], name: "index_music_list_items_on_music_list_id", using: :btree
-    t.index ["user_id"], name: "index_music_list_items_on_user_id", using: :btree
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["music_list_id"], name: "index_music_list_items_on_music_list_id"
+    t.index ["user_id"], name: "index_music_list_items_on_user_id"
   end
 
-  create_table "to_do_list_items", force: :cascade do |t|
-    t.integer  "user_id",                       null: false
-    t.integer  "to_do_list_id",                 null: false
-    t.string   "name",                          null: false
-    t.integer  "assignee_id"
+  create_table "to_do_list_items", id: :serial, force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "to_do_list_id", null: false
+    t.string "task", null: false
+    t.integer "assignee_id"
     t.datetime "due_by"
-    t.boolean  "completed",     default: false, null: false
-    t.boolean  "refreshed",     default: false, null: false
+    t.boolean "completed", default: false, null: false
+    t.boolean "refreshed", default: false, null: false
     t.datetime "archived_at"
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
-    t.index ["to_do_list_id"], name: "index_to_do_list_items_on_to_do_list_id", using: :btree
-    t.index ["user_id"], name: "index_to_do_list_items_on_user_id", using: :btree
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["to_do_list_id"], name: "index_to_do_list_items_on_to_do_list_id"
+    t.index ["user_id"], name: "index_to_do_list_items_on_user_id"
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "",    null: false
-    t.string   "encrypted_password",     default: "",    null: false
-    t.string   "reset_password_token"
+  create_table "users", id: :serial, force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,     null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.inet     "current_sign_in_ip"
-    t.inet     "last_sign_in_ip"
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
-    t.string   "invitation_token"
+    t.inet "current_sign_in_ip"
+    t.inet "last_sign_in_ip"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "invitation_token"
     t.datetime "invitation_created_at"
     t.datetime "invitation_sent_at"
     t.datetime "invitation_accepted_at"
-    t.integer  "invitation_limit"
-    t.string   "invited_by_type"
-    t.integer  "invited_by_id"
-    t.integer  "invitations_count",      default: 0
-    t.boolean  "is_test_account",        default: false
-    t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
-    t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true, using: :btree
-    t.index ["invitations_count"], name: "index_users_on_invitations_count", using: :btree
-    t.index ["invited_by_id"], name: "index_users_on_invited_by_id", using: :btree
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+    t.integer "invitation_limit"
+    t.string "invited_by_type"
+    t.integer "invited_by_id"
+    t.integer "invitations_count", default: 0
+    t.boolean "is_test_account", default: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
+    t.index ["invitations_count"], name: "index_users_on_invitations_count"
+    t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "users_lists", force: :cascade do |t|
-    t.integer "user_id",                      null: false
-    t.integer "list_id",                      null: false
+  create_table "users_lists", id: :serial, force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "list_id", null: false
     t.boolean "has_accepted", default: false, null: false
-    t.boolean "responded",    default: false, null: false
-    t.index ["list_id"], name: "index_users_lists_on_list_id", using: :btree
-    t.index ["user_id", "list_id"], name: "index_users_lists_on_user_id_and_list_id", unique: true, using: :btree
-    t.index ["user_id"], name: "index_users_lists_on_user_id", using: :btree
+    t.boolean "responded", default: false, null: false
+    t.index ["list_id"], name: "index_users_lists_on_list_id"
+    t.index ["user_id", "list_id"], name: "index_users_lists_on_user_id_and_list_id", unique: true
+    t.index ["user_id"], name: "index_users_lists_on_user_id"
   end
 
   add_foreign_key "book_list_items", "lists", column: "book_list_id"

--- a/spec/controllers/grocery_list_items_controller_spec.rb
+++ b/spec/controllers/grocery_list_items_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe GroceryListItemsController do
           "archived_at" => item[:archived_at],
           "id" => item[:id],
           "grocery_list_id" => item[:grocery_list_id],
-          "name" => item[:name],
+          "product" => item[:product],
           "purchased" => item[:purchased],
           "quantity" => item[:quantity],
           "refreshed" => item[:refreshed],
@@ -61,7 +61,7 @@ RSpec.describe GroceryListItemsController do
             grocery_list_item: {
               grocery_list_id: list.id,
               user_id: user.id,
-              name: "foo"
+              product: "foo"
             },
             list_id: list.id
           }
@@ -74,7 +74,7 @@ RSpec.describe GroceryListItemsController do
         post :create, params: {
           grocery_list_item: {
             grocery_list_id: list.id,
-            name: nil
+            product: nil
           },
           list_id: list.id
         }
@@ -88,15 +88,15 @@ RSpec.describe GroceryListItemsController do
   describe "PUT #update" do
     describe "with valid params" do
       it "updates a item" do
-        update_item = create :grocery_list_item, name: "foo"
+        update_item = create :grocery_list_item, product: "foo"
         put :update, params: {
           id: update_item.id,
-          grocery_list_item: { name: "bar" },
+          grocery_list_item: { product: "bar" },
           list_id: list.id
         }
         update_item.reload
 
-        expect(update_item.name).to eq "bar"
+        expect(update_item.product).to eq "bar"
       end
     end
 
@@ -105,7 +105,7 @@ RSpec.describe GroceryListItemsController do
         item = create :grocery_list_item
         put :update, params: {
           id: item.id,
-          grocery_list_item: { name: nil },
+          grocery_list_item: { product: nil },
           list_id: list.id
         }
 
@@ -117,7 +117,7 @@ RSpec.describe GroceryListItemsController do
 
   describe "DELETE #destroy" do
     it "destroys a item" do
-      delete_item = create :grocery_list_item, name: "foo"
+      delete_item = create :grocery_list_item, product: "foo"
       delete :destroy, params: {
         id: delete_item.id,
         list_id: list.id

--- a/spec/controllers/lists_controller_spec.rb
+++ b/spec/controllers/lists_controller_spec.rb
@@ -95,14 +95,14 @@ RSpec.describe ListsController do
           GroceryListItem.create!(
             user_id: user.id,
             grocery_list_id: list.id,
-            name: "foo",
+            product: "foo",
             quantity: 1,
             purchased: false
           )
           GroceryListItem.create!(
             user_id: user.id,
             grocery_list_id: list.id,
-            name: "foobar",
+            product: "foobar",
             quantity: 1,
             purchased: true,
             refreshed: false
@@ -110,7 +110,7 @@ RSpec.describe ListsController do
           GroceryListItem.create!(
             user_id: user.id,
             grocery_list_id: list.id,
-            name: "foobar",
+            product: "foobar",
             quantity: 1,
             purchased: true,
             refreshed: true
@@ -182,20 +182,20 @@ RSpec.describe ListsController do
           ToDoListItem.create!(
             user_id: user.id,
             to_do_list_id: list.id,
-            name: "foo",
+            task: "foo",
             completed: false
           )
           ToDoListItem.create!(
             user_id: user.id,
             to_do_list_id: list.id,
-            name: "foobar",
+            task: "foobar",
             completed: true,
             refreshed: false
           )
           ToDoListItem.create!(
             user_id: user.id,
             to_do_list_id: list.id,
-            name: "foobar",
+            task: "foobar",
             completed: true,
             refreshed: true
           )
@@ -421,7 +421,7 @@ RSpec.describe ListsController do
         GroceryListItem.create!(
           user: user,
           grocery_list: list,
-          name: "foo",
+          product: "foo",
           quantity: 1
         )
         expect do
@@ -472,7 +472,7 @@ RSpec.describe ListsController do
         ToDoListItem.create!(
           user: user,
           to_do_list: list,
-          name: "foo"
+          task: "foo"
         )
         expect do
           post :refresh_list, params: {

--- a/spec/controllers/to_do_list_items_controller_spec.rb
+++ b/spec/controllers/to_do_list_items_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ToDoListItemsController do
           "archived_at" => item[:archived_at],
           "id" => item[:id],
           "to_do_list_id" => item[:to_do_list_id],
-          "name" => item[:name],
+          "task" => item[:task],
           "completed" => item[:completed],
           "assignee_id" => item[:assignee_id],
           "due_by" => item[:due_by],
@@ -62,7 +62,7 @@ RSpec.describe ToDoListItemsController do
             to_do_list_item: {
               to_do_list_id: list.id,
               user_id: user.id,
-              name: "foo"
+              task: "foo"
             },
             list_id: list.id
           }
@@ -75,7 +75,7 @@ RSpec.describe ToDoListItemsController do
         post :create, params: {
           to_do_list_item: {
             to_do_list_id: list.id,
-            name: nil
+            task: nil
           },
           list_id: list.id
         }
@@ -89,24 +89,24 @@ RSpec.describe ToDoListItemsController do
   describe "PUT #update" do
     describe "with valid data" do
       it "updates a item" do
-        update_item = create :to_do_list_item, name: "foo", assignee_id: user.id
+        update_item = create :to_do_list_item, task: "foo", assignee_id: user.id
         put :update, params: {
           id: update_item.id,
-          to_do_list_item: { name: "bar" },
+          to_do_list_item: { task: "bar" },
           list_id: list.id
         }
         update_item.reload
 
-        expect(update_item.name).to eq "bar"
+        expect(update_item.task).to eq "bar"
       end
     end
 
     describe "with invalid data" do
       it "returns 422 and error message" do
-        update_item = create :to_do_list_item, name: "foo", assignee_id: user.id
+        update_item = create :to_do_list_item, task: "foo", assignee_id: user.id
         put :update, params: {
           id: update_item.id,
-          to_do_list_item: { name: "" },
+          to_do_list_item: { task: "" },
           list_id: list.id
         }
 
@@ -118,7 +118,7 @@ RSpec.describe ToDoListItemsController do
 
   describe "DELETE #destroy" do
     it "destroys a item" do
-      delete_item = create :to_do_list_item, name: "foo", assignee_id: user.id
+      delete_item = create :to_do_list_item, task: "foo", assignee_id: user.id
       delete :destroy, params: {
         id: delete_item.id,
         list_id: list.id

--- a/spec/factories/grocery_list_items.rb
+++ b/spec/factories/grocery_list_items.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :grocery_list_item do
     user
     grocery_list
-    name "MyString"
+    product "MyString"
     quantity 1
     purchased false
   end

--- a/spec/factories/to_do_list_items.rb
+++ b/spec/factories/to_do_list_items.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :to_do_list_item do
     user
     to_do_list
-    name "MyString"
+    task "MyString"
     assignee_id nil
     due_by "2017-09-24 14:35:48"
     completed false

--- a/spec/models/grocery_list_item_spec.rb
+++ b/spec/models/grocery_list_item_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe GroceryListItem do
-  let(:item) { create :grocery_list_item, name: "foo" }
-  let(:another_item) { create :grocery_list_item, name: "bar" }
+  let(:item) { create :grocery_list_item, product: "foo" }
+  let(:another_item) { create :grocery_list_item, product: "bar" }
 
   describe "validations" do
     it { expect(item).to be_valid }
@@ -15,8 +15,8 @@ RSpec.describe GroceryListItem do
       expect(item).to_not be_valid
     end
 
-    it "is invalid without name" do
-      item.name = nil
+    it "is invalid without product" do
+      item.product = nil
 
       expect(item).to_not be_valid
     end
@@ -35,20 +35,8 @@ RSpec.describe GroceryListItem do
   end
 
   describe ".ordered" do
-    it "returns items ordered by name" do
+    it "returns items ordered by product" do
       expect(GroceryListItem.ordered).to eq [another_item, item]
-    end
-  end
-
-  describe ".unique_names" do
-    let(:third_item) { create :grocery_list_item, name: "foo" }
-
-    it "returns unique items based on name" do
-      item
-      another_item
-      third_item
-      item_names = GroceryListItem.unique_names.map(&:name)
-      expect(item_names).to eq [another_item.name, item.name]
     end
   end
 

--- a/spec/models/to_do_list_item_spec.rb
+++ b/spec/models/to_do_list_item_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe ToDoListItem, type: :model do
-  let(:item) { create :to_do_list_item, name: "foo" }
-  let(:another_item) { create :to_do_list_item, name: "bar" }
+  let(:item) { create :to_do_list_item, task: "foo" }
+  let(:another_item) { create :to_do_list_item, task: "bar" }
 
   describe "validations" do
     it { expect(item).to be_valid }
@@ -14,8 +14,8 @@ RSpec.describe ToDoListItem, type: :model do
       expect(item).to_not be_valid
     end
 
-    it "is invalid when name is blank" do
-      item.name = nil
+    it "is invalid when task is blank" do
+      item.task = nil
       expect(item).to_not be_valid
     end
 


### PR DESCRIPTION
# Description

If the `name` attribute of an input includes `name` in it, some browsers on mobile will show contact recommendations. This is not ideal for form inputs for lists or items. To update this it was easiest to change the attributes on the model and trickle down those changes through the views.

Fixes https://www.pivotaltracker.com/story/show/158618478

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

The following were updated:

* Migrations
* Models
* Controllers
* Views

# How Has This Been Tested?

Tests have been updated at all levels to match the changes.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes