### PR TITLE
Fix location of "Filtering by" when category is long [#170852687]

### DIFF
--- a/client/app/bundles/Groceries/components/ListItemsContainer.jsx
+++ b/client/app/bundles/Groceries/components/ListItemsContainer.jsx
@@ -159,17 +159,17 @@ export default class ListItemsContainer extends Component {
               </div>
             </div>}
           {this.state.filter &&
-            <div>
+            <div className="float-right">
+              <span style={{ lineHeight: '2.5rem', marginRight: '1rem' }}>Filtering by:</span>
               <button
                 id="clear-filter-button"
                 type="button"
-                className="btn btn-outline-primary float-right"
+                className="btn btn-outline-primary"
                 style={{ marginRight: '1rem' }}
                 onClick={this.handleClearFilter}
               >
                 {this.state.filter} <i className="fa fa-trash" />
               </button>
-              <span className="float-right" style={{ lineHeight: '2.5rem', marginRight: '1rem' }}>Filtering by:</span>
             </div>}
         </div>
         {this.categories().sort().map(category => (


### PR DESCRIPTION
# Description

Fixes issue where, when a category is long and a user is on mobile, the "Filtering by" text appeared underneath the filter

Fixes #170852687

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

All tests pass. Manually tested with long and short filters.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
