### PR TITLE
Fix refresh list so it keeps item categories [#170913352]

### DIFF
--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -184,7 +184,8 @@ class ListsController < ApplicationController
         to_do_list: new_list,
         task: item[:task],
         assignee_id: item[:assignee_id],
-        due_by: item[:due_by]
+        due_by: item[:due_by],
+        category: item[:category]
       )
     end
   end
@@ -198,7 +199,8 @@ class ListsController < ApplicationController
         user: current_user,
         book_list: new_list,
         author: item[:author],
-        title: item[:title]
+        title: item[:title],
+        category: item[:category]
       )
     end
   end
@@ -213,7 +215,8 @@ class ListsController < ApplicationController
         music_list: new_list,
         title: item[:title],
         artist: item[:artist],
-        album: item[:album]
+        album: item[:album],
+        category: item[:category]
       )
     end
   end
@@ -227,7 +230,8 @@ class ListsController < ApplicationController
         user: current_user,
         grocery_list: new_list,
         product: item[:product],
-        quantity: item[:quantity]
+        quantity: item[:quantity],
+        category: item[:category]
       )
     end
   end

--- a/spec/controllers/lists_controller_spec.rb
+++ b/spec/controllers/lists_controller_spec.rb
@@ -517,7 +517,7 @@ RSpec.describe ListsController do
     context "when user is owner" do
       describe "when old list is a BookList" do
         it "creates new list" do
-          list = BookList.create!(name: "NewBookList", owner: user)
+          list = BookList.create!(name: "NewBookList", owner: user, completed: true)
           expect do
             post :refresh_list, params: {
               id: list.id
@@ -526,23 +526,27 @@ RSpec.describe ListsController do
         end
 
         it "creates new items" do
-          list = BookList.create!(name: "NewBookList", owner: user)
+          list = BookList.create!(name: "NewBookList", owner: user, completed: true)
           BookListItem.create!(
             user: user,
             book_list: list,
-            title: "foo"
+            title: "foo",
+            category: "foo"
           )
           expect do
             post :refresh_list, params: {
               id: list.id
             }
           end.to change(BookListItem, :count).by 1
+          new_list_item = BookListItem.last
+          expect(new_list_item[:title]).to eq "foo"
+          expect(new_list_item[:category]).to eq "foo"
         end
       end
 
       describe "when old list is a GroceryList" do
         it "creates new list" do
-          list = GroceryList.create!(name: "NewGroceryList", owner: user)
+          list = GroceryList.create!(name: "NewGroceryList", owner: user, completed: true)
           expect do
             post :refresh_list, params: {
               id: list.id
@@ -551,24 +555,28 @@ RSpec.describe ListsController do
         end
 
         it "creates new items" do
-          list = GroceryList.create!(name: "NewGroceryList", owner: user)
+          list = GroceryList.create!(name: "NewGroceryList", owner: user, completed: true)
           GroceryListItem.create!(
             user: user,
             grocery_list: list,
             product: "foo",
-            quantity: 1
+            quantity: 1,
+            category: "foo"
           )
           expect do
             post :refresh_list, params: {
               id: list.id
             }
           end.to change(GroceryListItem, :count).by 1
+          new_list_item = GroceryListItem.last
+          expect(new_list_item[:product]).to eq "foo"
+          expect(new_list_item[:category]).to eq "foo"
         end
       end
 
-      describe "when old list is a BookList" do
+      describe "when old list is a MusicList" do
         it "creates new list" do
-          list = MusicList.create!(name: "NewMusicList", owner: user)
+          list = MusicList.create!(name: "NewMusicList", owner: user, completed: true)
           expect do
             post :refresh_list, params: {
               id: list.id
@@ -577,23 +585,27 @@ RSpec.describe ListsController do
         end
 
         it "creates new items" do
-          list = MusicList.create!(name: "NewMusicList", owner: user)
+          list = MusicList.create!(name: "NewMusicList", owner: user, completed: true)
           MusicListItem.create!(
             user: user,
             music_list: list,
-            title: "foo"
+            title: "foo",
+            category: "foo"
           )
           expect do
             post :refresh_list, params: {
               id: list.id
             }
           end.to change(MusicListItem, :count).by 1
+          new_list_item = MusicListItem.last
+          expect(new_list_item[:title]).to eq "foo"
+          expect(new_list_item[:category]).to eq "foo"
         end
       end
 
-      describe "when old list is a GroceryList" do
+      describe "when old list is a ToDoList" do
         it "creates new list" do
-          list = ToDoList.create!(name: "NewToDoList", owner: user)
+          list = ToDoList.create!(name: "NewToDoList", owner: user, completed: true)
           expect do
             post :refresh_list, params: {
               id: list.id
@@ -602,17 +614,21 @@ RSpec.describe ListsController do
         end
 
         it "creates new items" do
-          list = ToDoList.create!(name: "NewToDoList", owner: user)
+          list = ToDoList.create!(name: "NewToDoList", owner: user, completed: true)
           ToDoListItem.create!(
             user: user,
             to_do_list: list,
-            task: "foo"
+            task: "foo",
+            category: "foo"
           )
           expect do
             post :refresh_list, params: {
               id: list.id
             }
           end.to change(ToDoListItem, :count).by 1
+          new_list_item = ToDoListItem.last
+          expect(new_list_item[:task]).to eq "foo"
+          expect(new_list_item[:category]).to eq "foo"
         end
       end
     end

--- a/spec/controllers/lists_controller_spec.rb
+++ b/spec/controllers/lists_controller_spec.rb
@@ -517,7 +517,9 @@ RSpec.describe ListsController do
     context "when user is owner" do
       describe "when old list is a BookList" do
         it "creates new list" do
-          list = BookList.create!(name: "NewBookList", owner: user, completed: true)
+          list = BookList.create!(name: "NewBookList",
+                                  owner: user,
+                                  completed: true)
           expect do
             post :refresh_list, params: {
               id: list.id
@@ -526,7 +528,9 @@ RSpec.describe ListsController do
         end
 
         it "creates new items" do
-          list = BookList.create!(name: "NewBookList", owner: user, completed: true)
+          list = BookList.create!(name: "NewBookList",
+                                  owner: user,
+                                  completed: true)
           BookListItem.create!(
             user: user,
             book_list: list,
@@ -546,7 +550,9 @@ RSpec.describe ListsController do
 
       describe "when old list is a GroceryList" do
         it "creates new list" do
-          list = GroceryList.create!(name: "NewGroceryList", owner: user, completed: true)
+          list = GroceryList.create!(name: "NewGroceryList",
+                                     owner: user,
+                                     completed: true)
           expect do
             post :refresh_list, params: {
               id: list.id
@@ -555,7 +561,9 @@ RSpec.describe ListsController do
         end
 
         it "creates new items" do
-          list = GroceryList.create!(name: "NewGroceryList", owner: user, completed: true)
+          list = GroceryList.create!(name: "NewGroceryList",
+                                     owner: user,
+                                     completed: true)
           GroceryListItem.create!(
             user: user,
             grocery_list: list,
@@ -576,7 +584,9 @@ RSpec.describe ListsController do
 
       describe "when old list is a MusicList" do
         it "creates new list" do
-          list = MusicList.create!(name: "NewMusicList", owner: user, completed: true)
+          list = MusicList.create!(name: "NewMusicList",
+                                   owner: user,
+                                   completed: true)
           expect do
             post :refresh_list, params: {
               id: list.id
@@ -585,7 +595,9 @@ RSpec.describe ListsController do
         end
 
         it "creates new items" do
-          list = MusicList.create!(name: "NewMusicList", owner: user, completed: true)
+          list = MusicList.create!(name: "NewMusicList",
+                                   owner: user,
+                                   completed: true)
           MusicListItem.create!(
             user: user,
             music_list: list,
@@ -605,7 +617,9 @@ RSpec.describe ListsController do
 
       describe "when old list is a ToDoList" do
         it "creates new list" do
-          list = ToDoList.create!(name: "NewToDoList", owner: user, completed: true)
+          list = ToDoList.create!(name: "NewToDoList",
+                                  owner: user,
+                                  completed: true)
           expect do
             post :refresh_list, params: {
               id: list.id
@@ -614,7 +628,9 @@ RSpec.describe ListsController do
         end
 
         it "creates new items" do
-          list = ToDoList.create!(name: "NewToDoList", owner: user, completed: true)
+          list = ToDoList.create!(name: "NewToDoList",
+                                  owner: user,
+                                  completed: true)
           ToDoListItem.create!(
             user: user,
             to_do_list: list,


### PR DESCRIPTION
# Description

Fix refresh of list so that it keeps categories for items.

Fixes #170913352

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

All tests pass. Tests added for refresh controller.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules